### PR TITLE
conf: Change the WKS_FILE setting to more weaker level

### DIFF
--- a/conf/machine/sparrow-hawk.conf
+++ b/conf/machine/sparrow-hawk.conf
@@ -33,7 +33,7 @@ UBOOT_MACHINE = "r8a779g3_sparrowhawk_defconfig"
 # ipl burning tool
 EXTRA_IMAGEDEPENDS += " ipl-burning"
 
-WKS_FILE ?= "rcar-singlepart-noloader.wks"
+WKS_FILE ??= "rcar-singlepart-noloader.wks"
 
 DEFAULTTUNE ?= "cortexa76"
 require conf/machine/include/arm/armv8-2a/tune-cortexa76.inc


### PR DESCRIPTION
Existing parrow-hawk.conf uses '?=' to set the wks file.  If an integrator such as AGL wants to override it, they need to use '='.  As a result, user difficult to overwrite it.
This patch changes the WKS_FILE setting from '?=' to '??=' to avoid these situations.