### PR TITLE
images: Split out the utility and packages to packagegroup and MACHINE_EXTRA_RRECOMMENDS

### DIFF
--- a/conf/machine/sparrow-hawk.conf
+++ b/conf/machine/sparrow-hawk.conf
@@ -38,3 +38,7 @@ WKS_FILE ?= "rcar-singlepart-noloader.wks"
 DEFAULTTUNE ?= "cortexa76"
 require conf/machine/include/arm/armv8-2a/tune-cortexa76.inc
 
+MACHINE_EXTRA_RRECOMMENDS = " \
+    linux-fitimage kernel-devicetree kernel-modules \
+    sparrow-hawk-fw u-boot \
+"

--- a/recipes-bsp/packagegroups/packagegroup-resesas-bsp.bb
+++ b/recipes-bsp/packagegroups/packagegroup-resesas-bsp.bb
@@ -1,0 +1,40 @@
+SUMMARY = "Package group for Renesas board"
+LICENSE = "MIT"
+
+COMPATIBLE_MACHINE = "(rcar-gen4)"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+PR = "r0"
+
+PACKAGES = " \
+    packagegroup-renesas-bsp-tools \
+    packagegroup-renesas-bsp-demo \
+"
+
+RDEPENDS:packagegroup-renesas-bsp-tools = " \
+    v4l-utils \
+    i2c-tools \
+    coreutils \
+    alsa-utils \
+    v4l-utils \
+    yavta \
+    libcamera \
+    libcamera-pycamera \
+    libcamera-gst \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    nvme-cli \
+    can-utils \
+    expand-rootfs \
+    pciutils \
+    usbutils \
+    libgpiod \
+"
+
+RDEPENDS:packagegroup-renesas-bsp-demo = " \
+    python3-pip \
+    python3-gpiod \
+"

--- a/recipes-core/images/core-image-minimal.inc
+++ b/recipes-core/images/core-image-minimal.inc
@@ -3,6 +3,7 @@ OVERRIDES .= ":${TARGET_SYS}"
 
 # Basic packages
 IMAGE_INSTALL:append = " \
+    ${CORE_IMAGE_BASE_INSTALL} \
     bash \
     packagegroup-renesas-bsp-tools \
     packagegroup-renesas-bsp-demo \

--- a/recipes-core/images/core-image-minimal.inc
+++ b/recipes-core/images/core-image-minimal.inc
@@ -4,34 +4,11 @@ OVERRIDES .= ":${TARGET_SYS}"
 # Basic packages
 IMAGE_INSTALL:append = " \
     bash \
-    v4l-utils \
-    i2c-tools \
-    coreutils \
-    kernel-devicetree \
-    alsa-utils \
-    v4l-utils \
-    yavta \
-    libcamera \
-    libcamera-pycamera \
-    libcamera-gst \
-    gstreamer1.0-plugins-base \
-    gstreamer1.0-plugins-good \
-    gstreamer1.0-plugins-bad \
-    nvme-cli \
-    can-utils \
-    expand-rootfs \
-    pciutils \
-    usbutils \
-    kernel-modules \
-    u-boot \
-    libgpiod \
-    python3-pip \
-    python3-gpiod \
+    packagegroup-renesas-bsp-tools \
+    packagegroup-renesas-bsp-demo \
 "
 # Sparrow-hawk specific packages
 IMAGE_INSTALL:append:sparrow-hawk = " \
-    linux-fitimage \
-    sparrow-hawk-fw \
     example-apps \
 "
 


### PR DESCRIPTION
Some packages forcefully install to the image using IMAGE_INSTALL. It causes loss of capability for image minimization and portability.

This patch changes to MACHINE_EXTRA_RRECOMMENDS and packagegroup from IMAGE_INSTALL.