### PR TITLE
base-files: Avoid execution for make-mod-scripts in case of using linux-dummy

### DIFF
--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -10,7 +10,9 @@ do_install:append () {
     printf "BSP version: ${BSP_VERSION}\n\n" >> ${D}${sysconfdir}/motd
 }
 
-inherit module-base
+KERNEL_VERSION = "${@bb.utils.contains("PREFERRED_PROVIDER_virtual/kernel", "linux-dummy", \
+    "Built by linux-dummy", \
+    "${@oe.utils.read_file('${STAGING_KERNEL_BUILDDIR}/kernel-abiversion')}", d)}"
 
 do_install_basefilesissue:append () {
     # Yocto version and codename


### PR DESCRIPTION
The base-files_%.bbappend inherits module-base.  It sets dependency to make-mod-scripts in every case.  As a result, make-mod-scripts will execute when using linux-dummy.  That causes a build error.

This patch removes 'inherit module-base' and adds another version picking-up method.