### PR TITLE
Fix up firmware installation issue in meta-sparrow-hawk

### DIFF
--- a/conf/machine/sparrow-hawk.conf
+++ b/conf/machine/sparrow-hawk.conf
@@ -42,5 +42,6 @@ require conf/machine/include/arm/armv8-2a/tune-cortexa76.inc
 
 MACHINE_EXTRA_RRECOMMENDS = " \
     linux-fitimage kernel-devicetree kernel-modules \
-    sparrow-hawk-fw u-boot \
+    linux-firmware-pcie-rcar linux-firmware-r8a779g-pcie-phy-license \
+    u-boot \
 "

--- a/recipes-core/images/initramfs-image.bb
+++ b/recipes-core/images/initramfs-image.bb
@@ -3,7 +3,10 @@ LICENSE = "MIT"
 inherit image
 
 IMAGE_FEATURES = ""
-IMAGE_INSTALL_LIST = "sparrow-hawk-fw busybox"
+IMAGE_INSTALL_LIST = " \
+    linux-firmware-pcie-rcar linux-firmware-r8a779g-pcie-phy-license \
+    busybox \
+"
 IMAGE_INSTALL_LIST:append = " kernel-module-pcie-rcar-gen4"
 
 INITRAMFS_IMAGE = "initramfs-image"

--- a/recipes-dev/ipl-burning/ipl-burning.bb
+++ b/recipes-dev/ipl-burning/ipl-burning.bb
@@ -15,8 +15,8 @@ ALLOW_EMPTY:${PN} = "1"
 ALLOW_EMPTY:${PN}-dev = "1"
 ALLOW_EMPTY:${PN}-staticdev = "1"
 
-PCIE_FIRMWARE = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/rcar_gen4_pcie.bin;md5sum=293bdf19d8e16d3c4d8179e438db921b"
-PCIE_FIRMWARE_LIC = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/LICENCE.r8a779g_pcie_phy;md5sum=0b20e76a9a004b83c4a1c87e2153bbad"
+PCIE_FIRMWARE = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/rcar_gen4_pcie.bin?h=20260519;md5sum=293bdf19d8e16d3c4d8179e438db921b"
+PCIE_FIRMWARE_LIC = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/LICENCE.r8a779g_pcie_phy?h=20260519;md5sum=0b20e76a9a004b83c4a1c87e2153bbad"
 
 SRC_URI:append = " \
     file://burn.py \
@@ -67,8 +67,8 @@ do_deploy() {
     install -m 0644 ${UNPACKDIR}/Flash_writer_sparrow_hawk_CR52.mot ${DEPLOYDIR}/${PN}
     install -m 0644 ${DEPLOY_DIR}/images/${MACHINE}/flash.bin ${DEPLOYDIR}/${PN}
     cp -r  ${DEPLOY_DIR}/licenses/${MACHINE_LIC}/u-boot ${DEPLOYDIR}/${PN}/License/u-boot_licenses
-    install -m 755 ${UNPACKDIR}/rcar_gen4_pcie.bin ${DEPLOYDIR}/${PN}
-    install -m 755 ${UNPACKDIR}/LICENCE.r8a779g_pcie_phy ${DEPLOYDIR}/${PN}/License
+    install -m 755 ${UNPACKDIR}/rcar_gen4_pcie.bin* ${DEPLOYDIR}/${PN}/rcar_gen4_pcie.bin
+    install -m 755 ${UNPACKDIR}/LICENCE.r8a779g_pcie_phy* ${DEPLOYDIR}/${PN}/License/LICENCE.r8a779g_pcie_phy
 
     # install embedded python binary for Windows environment
     PYTHON_DIR=${DEPLOYDIR}/${PN}/python-embed-amd64

--- a/recipes-kernel/linux/sparrow-hawk-fw.bb
+++ b/recipes-kernel/linux/sparrow-hawk-fw.bb
@@ -1,26 +1,20 @@
-SUMMARY = "Binary firmware for Sparrow hawk board"
+SUMMARY = "Backward Compatibility:Binary firmware for Sparrow hawk board"
 LICENSE = "CLOSED"
-PR = "r0"
+PR = "r1"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 COMPATIBLE_MACHINE = "sparrow-hawk"
 
-PCIE_FIRMWARE = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/rcar_gen4_pcie.bin;md5sum=293bdf19d8e16d3c4d8179e438db921b"
-PCIE_FIRMWARE_LIC = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/plain/LICENCE.r8a779g_pcie_phy;md5sum=0b20e76a9a004b83c4a1c87e2153bbad"
-
-SRC_URI:append:sparrow-hawk = " \
-    ${PCIE_FIRMWARE} \
-    ${PCIE_FIRMWARE_LIC} \
-"
+SRC_URI = ""
 
 S = "${UNPACKDIR}"
 
+PACKAGES = "${PN}"
+ALLOW_EMPTY:${PN} = "1"
+RDEPENDS:${PN}:sparrow-hawk = " \
+    linux-firmware-pcie-rcar \
+    linux-firmware-r8a779g-pcie-phy-license \
+"
+do_configure[noexec] = "1"
 do_compile[noexec] = "1"
-FILES:${PN}:sparrow-hawk += "/usr/lib/firmware/"
-
-do_install:append:sparrow-hawk () {
-    install -d ${D}/usr/lib/firmware
-    install -m 755 ${UNPACKDIR}/rcar_gen4_pcie.bin ${D}/usr/lib/firmware
-    install -m 755 ${UNPACKDIR}/LICENCE.r8a779g_pcie_phy ${D}/usr/lib/firmware
-}
-
+do_install[noexec] = "1"


### PR DESCRIPTION
Alternative patches of 
e05b3389006f0052349746918c587534a11a805b
and
52b05eb2771e91164379814aa08b9d92210e7f69